### PR TITLE
Make which more featureful, add a lot more tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ description= "A Rust equivalent of Unix command \"which\"."
 
 [dependencies]
 libc = "0.2.10"
+
+[dev-dependencies]
+tempdir = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,6 @@ repository = "https://github.com/fangyuanziti/which-rs.git"
 documentation = "http://fangyuanziti.github.io/which-rs/which/"
 license = "MIT"
 description= "A Rust equivalent of Unix command \"which\"."
+
+[dependencies]
+libc = "0.2.10"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 
 use std::path::PathBuf;
 use std::{env, fs};
+use std::ffi::OsStr;
 
 fn is_exist(bin_path: &PathBuf) -> bool {
 
@@ -39,13 +40,13 @@ fn is_exist(bin_path: &PathBuf) -> bool {
 /// assert_eq!(result, PathBuf::from("/usr/bin/rustc"));
 ///
 /// ```
-pub fn which(binary_name: &'static str)
+pub fn which<T: AsRef<OsStr>>(binary_name: T)
              -> Result<PathBuf, &'static str> {
 
     let path_buf = env::var_os("PATH").and_then(
         |paths| -> Option<PathBuf> {
             for path in env::split_paths(&paths) {
-                let bin_path = path.join(binary_name);
+                let bin_path = path.join(binary_name.as_ref());
                 if is_exist(&bin_path) {
                     return Some(bin_path);
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 //! ```
 
 extern crate libc;
+#[cfg(test)]
+extern crate tempdir;
 
 use std::path::{Path,PathBuf};
 use std::{env, fs};
@@ -61,8 +63,15 @@ fn is_executable(_path: &Path) -> bool { true }
 /// ```
 pub fn which<T: AsRef<OsStr>>(binary_name: T)
              -> Result<PathBuf, &'static str> {
+    which_in(binary_name, env::var_os("PATH"))
+}
 
-    let path_buf = env::var_os("PATH").and_then(
+/// Find `binary_name` in the path list `paths`.
+pub fn which_in<T, U>(binary_name: T, paths: Option<U>)
+             -> Result<PathBuf, &'static str>
+                where T: AsRef<OsStr>,
+                U: AsRef<OsStr> {
+    let path_buf = paths.and_then(
         |paths| -> Option<PathBuf> {
             for path in env::split_paths(&paths) {
                 let bin_path = path.join(binary_name.as_ref());
@@ -81,23 +90,126 @@ pub fn which<T: AsRef<OsStr>>(binary_name: T)
 
 }
 
+#[cfg(test)]
+mod test {
+    use super::*;
 
-#[test]
-fn it_works() {
-    use std::process::Command;
-    let result = which("rustc");
-    assert!(result.is_ok());
+    use std::env;
+    use std::ffi::OsString;
+    use std::fs;
+    use std::io;
+    use std::path::{Path,PathBuf};
+    use tempdir::TempDir;
 
-    let which_result = Command::new("which")
-        .arg("rustc")
-        .output();
+    struct TestFixture {
+        /// Temp directory.
+        pub tempdir: TempDir,
+        /// $PATH
+        pub paths: OsString,
+        /// Binaries created in $PATH
+        pub bins: Vec<PathBuf>,
+    }
 
-    assert_eq!(String::from(result.unwrap().to_str().unwrap()),
-        String::from_utf8(which_result.unwrap().stdout).unwrap().trim());
-}
+    const SUBDIRS: &'static [&'static str] = &["a", "b", "c"];
+    const BIN_NAME: &'static str = "bin";
 
-#[test]
-fn dont_works() {
-    let result = which("cargo-no-exist");
-    assert_eq!(result, Err("Can not find binary path"))
+    #[cfg(unix)]
+    fn mk_bin(dir: &Path, path: &str) -> io::Result<PathBuf> {
+        use libc;
+        use std::os::unix::fs::OpenOptionsExt;
+        let bin = dir.join(path);
+        fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .mode(0o666 | (libc::S_IXUSR as u32))
+            .open(&bin)
+            .and_then(|_f| bin.canonicalize())
+    }
+
+    fn touch(dir: &Path, path: &str) -> io::Result<PathBuf> {
+        let b = dir.join(path);
+        fs::File::create(&b)
+            .and_then(|_f| b.canonicalize())
+    }
+
+    #[cfg(not(unix))]
+    fn mk_bin(dir: &Path, path: &str) -> io::Result<PathBuf> {
+        touch(dir, path)
+    }
+
+    impl TestFixture {
+        pub fn new() -> TestFixture {
+            let tempdir = TempDir::new("which_tests").unwrap();
+            let mut builder = fs::DirBuilder::new();
+            builder.recursive(true);
+            let mut paths = vec!();
+            let mut bins = vec!();
+            for d in SUBDIRS.iter() {
+                let p = tempdir.path().join(d);
+                builder.create(&p).unwrap();
+                bins.push(mk_bin(&p, &BIN_NAME).unwrap());
+                paths.push(p);
+            }
+            TestFixture {
+                tempdir: tempdir,
+                paths: env::join_paths(paths).unwrap(),
+                bins: bins,
+            }
+        }
+
+        #[allow(dead_code)]
+        pub fn touch(&self, path: &str) -> io::Result<PathBuf> {
+            touch(self.tempdir.path(), &path)
+        }
+
+        pub fn mk_bin(&self, path: &str) -> io::Result<PathBuf> {
+            mk_bin(self.tempdir.path(), &path)
+        }
+    }
+
+    fn _which(f: &TestFixture, path: &str) -> Result<PathBuf, &'static str> {
+        which_in(path, Some(f.paths.clone()))
+    }
+
+    #[test]
+    fn it_works() {
+        use std::process::Command;
+        let result = which("rustc");
+        assert!(result.is_ok());
+
+        let which_result = Command::new("which")
+            .arg("rustc")
+            .output();
+
+        assert_eq!(String::from(result.unwrap().to_str().unwrap()),
+                   String::from_utf8(which_result.unwrap().stdout).unwrap().trim());
+    }
+
+    #[test]
+    fn test_which() {
+        let f = TestFixture::new();
+        assert_eq!(_which(&f, &BIN_NAME).unwrap(), f.bins[0])
+    }
+
+    #[test]
+    fn test_which_not_found() {
+        let f = TestFixture::new();
+        assert!(_which(&f, "a").is_err());
+    }
+
+    #[test]
+    fn test_which_second() {
+        let f = TestFixture::new();
+        let b = f.mk_bin("b/another").unwrap();
+        assert_eq!(_which(&f, "another").unwrap(), b);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_which_non_executable() {
+        // Shouldn't return non-executable files.
+        let f = TestFixture::new();
+        f.touch("b/another").unwrap();
+        assert!(_which(&f, "another").is_err());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 //! which
 //!
-//! A Rust equivalent of Unix command "which".
-//! # Exmaple:
+//! A Rust equivalent of Unix command `which(1)`.
+//! # Example:
 //!
-//! To find wihch rustc exectable binary is using.
+//! To find which rustc executable binary is using:
 //!
 //! ``` norun
 //! use which::which;


### PR DESCRIPTION
Hi there! I needed the functionality of this crate in [a project I'm working on](https://github.com/luser/sccache2), but I needed it to do a few more things above what your crate currently provides. I wrote my own implementation that met my needs, but I think it'd be great if I could just have my project use your crate instead.

I tried to split my changes up into smaller commits, hopefully that makes them easier to understand.

The changes are, in order:

1. Change binary_name parameter to `AsRef<OsStr>`. This lets callers pass in anything that can be taken as an `&OsStr`, so you can pass any of `&str`, `String`, `OsString`, `Path`.
2. Don't return non-executable files. This matches the behavior of the `which` command on POSIX systems. I pulled in the `libc` crate to call `libc::access` for this, since it's sort of complicated to determine otherwise.
3. Add more exhaustive tests. I wrote a number of tests for the implementation I wrote, and a little `TestFixture` struct to simplify writing tests, so this copies in most of that. This pulls in the `tempdir` crate as a dev-dependency, and also adds a `which_in` function which lets callers pass in a value for `$PATH`, which is mostly useful for testing.
4. Support absolute and relative paths passed in. This matches the behavior of the `which` command, except that the command will return relative paths (that exist and are executable) untouched, where my implementation returns them converted to absolute paths. I think that's slightly more useful.
5. Add exe extension to filenames on Windows. This makes cross-platform usage a little nicer, so that `which("rustc")` would find `rustc.exe`, for example. This matches the behavior of the system `which` in an msys shell. I wound up skipping the `it_works` test on Windows because on a normal Windows system we won't have a `which` system binary to compare against, and even in an msys shell `which` is a shell script, so trying to execute it from Rust doesn't work.
6. Cleanup crate docs. Just fixing a few typos and things.

Thanks for writing this crate, I hope we can merge these changes!