### PR TITLE
add forgotten `use std::ascii::AsciiExt;`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ extern crate tempdir;
 
 use std::path::{Path, PathBuf};
 use std::{env, fs};
+use std::ascii::AsciiExt;
 #[cfg(unix)]
 use std::ffi::CString;
 use std::ffi::OsStr;


### PR DESCRIPTION
If I compile master, I get:
```
error[E0599]: no method named `eq_ignore_ascii_case` found for type `&str` in the current scope
  --> /home/symphorien/.cargo/registry/src/github.com-1ecc6299db9ec823/which-1.0.4/src/lib.rs:37:24
   |
37 |             .map(|e| e.eq_ignore_ascii_case(env::consts::EXE_EXTENSION)) {
   |                        ^^^^^^^^^^^^^^^^^^^^
   |
   = help: items from traits can only be used if the trait is in scope
   = note: the following trait is implemented but not in scope, perhaps add a `use` for it:
           candidate #1: `use std::ascii::AsciiExt;`

error: aborting due to previous error

error: Could not compile `which`.
```
Using the tip of the compiler, here is a fix :)
Tests still pass.
Please release a new version on crates.io after merging :)