### PR TITLE
Implement Error trait for Failure usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ categories = ["os", "filesystem"]
 keywords = ["which", "which-rs", "unix", "command"]
 
 [dependencies]
+failure = "0.1.1"
 libc = "0.2.10"
 
 [dev-dependencies]
-failure = "0.1.1"
 tempdir = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ keywords = ["which", "which-rs", "unix", "command"]
 libc = "0.2.10"
 
 [dev-dependencies]
+failure = "0.1.1"
 tempdir = "0.3.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "which"
-version = "1.0.5"
+version = "2.0.0"
 authors = ["fangyuanziti <tiziyuanfang@gmail.com>"]
 repository = "https://github.com/fangyuanziti/which-rs.git"
 documentation = "https://docs.rs/which/"
 license = "MIT"
-description= "A Rust equivalent of Unix command \"which\". Locate installed execuable in cross platforms."
-readme= "README.md"
+description = "A Rust equivalent of Unix command \"which\". Locate installed execuable in cross platforms."
+readme = "README.md"
 categories = ["os", "filesystem"]
 keywords = ["which", "which-rs", "unix", "command"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use std::{env, fs};
 
 // Remove the `AsciiExt` will make `which-rs` build failed in older versions of Rust.
 // Please Keep it here though we don't need it in the new Rust version(>=1.23).
-#[allow(unused)]
+#[allow(unused_imports)]
 use std::ascii::AsciiExt;
 
 #[cfg(unix)]
@@ -177,10 +177,10 @@ impl Finder {
                 .and_then(|paths| {
                     env::split_paths(paths.as_ref())
                         .map(|p| ensure_exe_extension(p.join(binary_name.as_ref())))
-                        .skip_while(|p| !(binary_checker.is_valid(&p)))
+                        .skip_while(|p| !(binary_checker.is_valid(p)))
                         .next()
                 })
-                .ok_or(Error::new("Cannot find binary path"))
+                .ok_or_else(|| Error::new("Cannot find binary path"))
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 //!
 //! ```
 
+#[cfg(test)]
+extern crate failure;
 extern crate libc;
 #[cfg(test)]
 extern crate tempdir;
@@ -102,6 +104,18 @@ where
 #[derive(Debug)]
 pub struct Error {
     msg: &'static str,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+impl std::error::Error for Error {
+    fn description(&self) -> &str {
+        self.msg
+    }
 }
 
 impl Error {
@@ -486,5 +500,18 @@ mod test {
         let f = TestFixture::new();
         f.touch("b/another").unwrap();
         assert!(_which(&f, "b/another").is_err());
+    }
+
+    #[test]
+    fn test_failure() {
+        let f = TestFixture::new();
+
+        let run = || -> std::result::Result<PathBuf, failure::Error> {
+            // Test the conversion to failure
+            let p = _which(&f, "./b/bin")?;
+            Ok(p)
+        };
+
+        let _ = run();
     }
 }


### PR DESCRIPTION
Hi I have a PR here with the intent to have `which-rs` play nice with `failure` crate, need to check if you willing to accept the PR. The changes are as below:

* Change API to return struct instead of `'static str` as error
* Implement `Error` trait for the new struct
* Unit test to include compilation test for `failure` crate usage
* Apply `cargo fmt` and fix `cargo clippy` issues
* Bump version to `2.0.0` due to API changes